### PR TITLE
Shorthand for supporting one release and debug config

### DIFF
--- a/lib/xcake/configurable.rb
+++ b/lib/xcake/configurable.rb
@@ -86,7 +86,7 @@ module Xcake
     #
     # @return [Configuration] the new or existing debug configuration
     #
-    def debug_configuration(name, &block)
+    def debug_configuration(name=nil, &block)
       build_configuration(:debug, name, &block)
     end
 
@@ -95,7 +95,7 @@ module Xcake
     #
     # @return [Configuration] the new or existing release configuration
     #
-    def release_configuration(name, &block)
+    def release_configuration(name=nil, &block)
       build_configuration(:release, name, &block)
     end
 
@@ -103,8 +103,12 @@ module Xcake
 
     def build_configuration(method, name, &block)
       configuration_name = send("#{method}_configurations")
-      configuration = configuration_name.detect do |c|
-        c.name == name.to_s
+      if name == nil
+        configuration = confugration_name.first
+      else
+        configuration = configuration_name.detect do |c|
+          c.name == name.to_s
+        end
       end
 
       if configuration.nil?

--- a/lib/xcake/configurable.rb
+++ b/lib/xcake/configurable.rb
@@ -104,7 +104,7 @@ module Xcake
     def build_configuration(method, name, &block)
       configuration_name = send("#{method}_configurations")
       if name.nil?
-        configuration = confugration_name.first
+        configuration = configuration_name.first
       else
         configuration = configuration_name.detect do |c|
           c.name == name.to_s

--- a/lib/xcake/configurable.rb
+++ b/lib/xcake/configurable.rb
@@ -86,7 +86,7 @@ module Xcake
     #
     # @return [Configuration] the new or existing debug configuration
     #
-    def debug_configuration(name=nil, &block)
+    def debug_configuration(name = nil, &block)
       build_configuration(:debug, name, &block)
     end
 
@@ -95,7 +95,7 @@ module Xcake
     #
     # @return [Configuration] the new or existing release configuration
     #
-    def release_configuration(name=nil, &block)
+    def release_configuration(name = nil, &block)
       build_configuration(:release, name, &block)
     end
 
@@ -103,7 +103,7 @@ module Xcake
 
     def build_configuration(method, name, &block)
       configuration_name = send("#{method}_configurations")
-      if name == nil
+      if name.nil?
         configuration = confugration_name.first
       else
         configuration = configuration_name.detect do |c|

--- a/spec/configurable_spec.rb
+++ b/spec/configurable_spec.rb
@@ -25,7 +25,7 @@ module Xcake
       it "should store build configuration" do
         expect(@configurable.debug_configurations.count).to eq(1)
       end
-      
+
       it "should use that configuration if no name is specified" do
         expect(@configuration.debug_configuration).to eq(@configuration)
       end

--- a/spec/configurable_spec.rb
+++ b/spec/configurable_spec.rb
@@ -25,6 +25,10 @@ module Xcake
       it "should store build configuration" do
         expect(@configurable.debug_configurations.count).to eq(1)
       end
+      
+      it "should use that configuration if no name is specified" do
+        expect(@configuration.debug_configuration).to eq(@configuration)
+      end
 
       context "that already exists" do
 
@@ -46,6 +50,10 @@ module Xcake
 
       it "should store build configuration" do
         expect(@configurable.release_configurations.count).to eq(1)
+      end
+
+      it "should use that configuration if no name is specified" do
+        expect(@configuration.release_configuration).to eq(@configuration)
       end
 
       context "that already exists" do

--- a/spec/configurable_spec.rb
+++ b/spec/configurable_spec.rb
@@ -27,7 +27,7 @@ module Xcake
       end
 
       it "should use that configuration if no name is specified" do
-        expect(@configuration.debug_configuration).to eq(@configuration)
+        expect(@configurable.debug_configuration).to eq(@configuration)
       end
 
       context "that already exists" do
@@ -53,7 +53,7 @@ module Xcake
       end
 
       it "should use that configuration if no name is specified" do
-        expect(@configuration.release_configuration).to eq(@configuration)
+        expect(@configurable.release_configuration).to eq(@configuration)
       end
 
       context "that already exists" do


### PR DESCRIPTION
If only one debug and release configuration are specified, then you don't need to specify the name in the Cakefile

```ruby
debug_configuration :Debug

application_for ... do |target|
  target.debug_configuration(:Debug).product_bundle_identifier = "com.your.app"
  # becomes
  target.debug_configuration.product_bundle_identifier = "com.your.app"
```