### PR TITLE
Truncates the preceding whitespace, using the 'strip_heredoc' method from Active Support

### DIFF
--- a/lib/xcake/target/sugar.rb
+++ b/lib/xcake/target/sugar.rb
@@ -1,11 +1,17 @@
 require "xcodeproj"
 
 module Xcake
+  def self.strip_heredoc(docs)
+    indent = docs.scan(/^[ \t]*(?=\S)/).min
+    indent_len = (indent || "").length
+    docs.gsub(/^[ \t]{#{indent_len}}/, "")
+  end
+
   class Target
     def shell_script_build_phase(name, script)
       phase = ShellScriptBuildPhase.new
       phase.name = name
-      phase.script = script
+      phase.script = Xcake.strip_heredoc(script)
       build_phases << phase
       phase
     end

--- a/spec/target/sugar_spec.rb
+++ b/spec/target/sugar_spec.rb
@@ -8,13 +8,17 @@ module Xcake
 
     context "when adding a shell script build phase with a string" do
       before :each do
-        @target.shell_script_build_phase("Hello World", <<-SCRIPT)
+        @phase = @target.shell_script_build_phase("Hello World", <<-SCRIPT)
           echo hello world
         SCRIPT
       end
 
       it "should add the build phase" do
         expect(@target.build_phases.length).to eq(1)
+      end
+
+      it "should truncate the preceding whitespace" do
+        expect(@phase.script).not_to match(/^[ \t]/)
       end
     end
   end


### PR DESCRIPTION
One of my shell scripts includes *its own* heredocs (in the bash script, that is), and having preceding whitespace was breaking that script.

Fixes this situation:

Running:

```ruby
target.shell_script_build_phase("Check Pods Manifest.lock", <<-SCRIPT)
    diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" > /dev/null
    if [[ $? != 0 ]] ; then
#### these bash heredocs should not be indented in the final script ####
        cat << EOM
    error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
    EOM
        exit 1
    fi
SCRIPT
```

Instead of the script including the `'    '` in front, the common preceding whitespace is removed:

```bash
diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" > /dev/null
if [[ $? != 0 ]] ; then
    cat << EOM
error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
EOM
    exit 1
fi
```