### PR TITLE
Attempt to support `xcconfig` files

### DIFF
--- a/lib/xcake.rb
+++ b/lib/xcake.rb
@@ -14,6 +14,7 @@ require "xcake/configuration/proxies/preproccessor_definitions_setting_proxy"
 require "xcake/configurable"
 
 require "xcake/generator/build_phase"
+require "xcake/generator/build_phase/ignore_phase"
 require "xcake/generator/build_phase/compile_source_build_phase"
 require "xcake/generator/build_phase/compile_xcdatamodeld_build_phase"
 require "xcake/generator/build_phase/copy_resources_build_phase"
@@ -23,6 +24,7 @@ require "xcake/generator/build_phase_registry"
 
 require "xcake/generator/configuration"
 require "xcake/generator/path"
+require "xcake/generator/base_config"
 require "xcake/generator/project"
 require "xcake/generator/target"
 

--- a/lib/xcake/configuration.rb
+++ b/lib/xcake/configuration.rb
@@ -14,7 +14,7 @@ module Xcake
 
     include Visitable
 
-    # @return [String>] the name of the configuration
+    # @return [String] the name of the configuration
     #
     attr_accessor :name
 

--- a/lib/xcake/configuration.rb
+++ b/lib/xcake/configuration.rb
@@ -26,6 +26,15 @@ module Xcake
     #
     attr_accessor :settings
 
+    # @return [String] the name of the xcconfig file to use for
+    #         the build configuration.  This is resolved to a PBXFileReference.
+    #
+    attr_accessor :configuration_file
+
+    # @return [XCBuildConfiguration] the Xcodeproj XCBuildConfiguration object
+    #         that this Configuration generated
+    attr_accessor :native_configuration
+
     # @param    [String] name
     #           the name of the configuration.
     #           This is used for the build configuration name.

--- a/lib/xcake/generator/base_config.rb
+++ b/lib/xcake/generator/base_config.rb
@@ -1,0 +1,61 @@
+module Xcake
+  module Generator
+    # This generator processes the source tree and
+    # assigns the base_configuration_reference if
+    # a match is found
+    #
+    class BaseConfig
+      include Visitor
+
+      # @return [XCBuildConfiguration] the configuration to modify
+      #
+      attr_accessor :native_configuration
+
+      # @return [String] the name of the xcconfig file to search for
+      #
+      attr_accessor :configuration_file
+
+      # @param [XCBuildConfiguration] native_configuration
+      #        The build configuration that should be modified
+      # @param [String] configuration_file
+      #        The name of the file that should be assigned
+      #
+      def initialize(project, native_configuration, configuration_file)
+        @project = project
+        @native_configuration = native_configuration
+        @configuration_file = configuration_file
+      end
+
+      # Find the group which this node
+      # should be added to.
+      #
+      # This dictates where it shows up
+      # in the groups structure.
+      #
+      # @param [Node] the node
+      #
+      # @return [PBXGroup] the group
+      #
+      def group_for_node(node)
+        return @project.main_group unless node.parent
+
+        @project.main_group.find_subpath(node.parent.path, true)
+      end
+
+      protected
+
+      def visit_node(node)
+        return unless node.path
+        return unless File.basename(node.path) == @configuration_file
+
+        puts "Assigning #{node.path}..."
+        group = group_for_node(node)
+        file_reference = group.new_reference(node.path)
+        @native_configuration.base_configuration_reference = file_reference
+      end
+
+      def leave_node(node)
+      end
+    end
+  end
+end

--- a/lib/xcake/generator/build_phase.rb
+++ b/lib/xcake/generator/build_phase.rb
@@ -60,7 +60,12 @@ module Xcake
 
       protected
 
+      def adding_node(node)
+        puts "Adding #{node.path}..."
+      end
+
       def visit_node(node)
+        adding_node(node)
 
         group = group_for_node(node)
         file_reference = group.new_reference(node.path)

--- a/lib/xcake/generator/build_phase/ignore_phase.rb
+++ b/lib/xcake/generator/build_phase/ignore_phase.rb
@@ -1,0 +1,19 @@
+module Xcake
+  module Generator
+    # This build phase generator detects
+    # files and adds them to the copy resources phase.
+    #
+    class IgnorePhase < BuildPhase
+      def self.can_install_node(node)
+        !File.directory?(node.path) &&
+          [".xcconfig", ".plist"].include?(File.extname(node.path))
+      end
+
+      def adding_node(node)
+      end
+
+      def add_file_reference_to_target(file_reference, target)
+      end
+    end
+  end
+end

--- a/lib/xcake/generator/build_phase_registry.rb
+++ b/lib/xcake/generator/build_phase_registry.rb
@@ -14,11 +14,12 @@ module Xcake
         #
         def self.build_phase_generators
           [
-              CompileSourceBuildPhase,
-              CompileXCDataModeldBuildPhase,
-              HeaderFileBuildPhase,
-              CopyXCAssetsBuildPhase,
-              CopyResourcesBuildPhase
+            IgnorePhase,
+            CompileSourceBuildPhase,
+            CompileXCDataModeldBuildPhase,
+            HeaderFileBuildPhase,
+            CopyXCAssetsBuildPhase,
+            CopyResourcesBuildPhase
           ]
         end
 

--- a/lib/xcake/generator/configuration.rb
+++ b/lib/xcake/generator/configuration.rb
@@ -37,6 +37,7 @@ module Xcake
         build_configuration.build_settings = configuration.settings
 
         @configuration_target.build_configurations << build_configuration
+        configuration.native_configuration = build_configuration
       end
 
       def leave_configuration(configuration)

--- a/lib/xcake/generator/path.rb
+++ b/lib/xcake/generator/path.rb
@@ -24,8 +24,6 @@ module Xcake
 
         return unless node.path
 
-        puts "Adding #{node.path}..."
-
         generator_class = BuildPhase::Registry.generator_for_node(node)
 
         if generator_class

--- a/lib/xcake/generator/project.rb
+++ b/lib/xcake/generator/project.rb
@@ -35,6 +35,20 @@ module Xcake
         generator = Path.new(@project)
         @root_node.accept(generator)
 
+        project.targets.each do |t|
+          all_configurations = t.debug_configurations + t.release_configurations
+
+          all_configurations.each do |c|
+            next unless c.configuration_file
+
+            generator = BaseConfig.new(
+              @project,
+              c.native_configuration,
+              c.configuration_file)
+            @root_node.accept(generator)
+          end
+        end
+
         puts "Writing Project..."
         
         @project.recreate_user_schemes


### PR DESCRIPTION
Ignores xcconfig and plist files during source/resource inspection.

```ruby
t.all_configurations.include_files << "Pods/Target Support Files/**/*.xcconfig"
t.release_configuration.configuration_file = "Pods.release.xcconfig"
```

Very hacky, no specs.  *for review & feedback only*