### PR TITLE
Removes `Xcake.strip_heredoc(String)`

### DIFF
--- a/lib/xcake/target/sugar.rb
+++ b/lib/xcake/target/sugar.rb
@@ -1,12 +1,6 @@
 require "xcodeproj"
 
 module Xcake
-  def self.strip_heredoc(docs)
-    indent = docs.scan(/^[ \t]*(?=\S)/).min
-    indent_len = (indent || "").length
-    docs.gsub(/^[ \t]{#{indent_len}}/, "")
-  end
-
   class Target
     def shell_script_build_phase(name, script)
       phase = ShellScriptBuildPhase.new


### PR DESCRIPTION
Looks like you had a chance to move this method to `string.rb`, so this can just be removed.