### PR TITLE
Fixes #82

### DIFF
--- a/lib/xcake/generator/project_structure_generator.rb
+++ b/lib/xcake/generator/project_structure_generator.rb
@@ -15,9 +15,6 @@ module Xcake
       puts "Resolving Project..."
 
       @project = project
-
-      @project.configuration :Debug, :debug if @project.configurations_of_type(:debug).count == 0
-      @project.configuration :Release, :release if @project.configurations_of_type(:release).count == 0
     end
 
     def leave_project(project)

--- a/lib/xcake/project.rb
+++ b/lib/xcake/project.rb
@@ -52,6 +52,9 @@ module Xcake
       self.name = name
       self.targets = []
 
+      debug_configuration :Debug
+      release_configuration :Release
+
       block.call(self) if block_given?
     end
 

--- a/lib/xcake/target.rb
+++ b/lib/xcake/target.rb
@@ -180,6 +180,9 @@ module Xcake
       @project = project
       @build_phases = []
 
+      debug_configuration :Debug
+      release_configuration :Release
+
       block.call(self) if block_given?
     end
 

--- a/spec/generator/project_structure_generator_spec.rb
+++ b/spec/generator/project_structure_generator_spec.rb
@@ -7,21 +7,9 @@ module Xcake
       @generator = ProjectStructureGenerator.new(@context)
     end
 
-    context "when resolving project with no configurations" do
+    context "when resolving project" do
       before :each do
         @project = double("Project").as_null_object
-
-        allow(@project).to receive(:configurations_of_type).and_return([])
-      end
-
-      it "should create a default debug configuration" do
-        expect(@project).to receive(:configuration).with(:Debug, :debug)
-        @generator.visit_project(@project)
-      end
-
-      it "should create a default release configuration" do
-        expect(@project).to receive(:configuration).with(:Release, :release)
-        @generator.visit_project(@project)
       end
 
       it "should store project" do


### PR DESCRIPTION
Fixes #82 caused by configurations not being created early enough, we now create the default `Debug` and `Release` configurations earlier.