### PR TITLE
Use target.type when creating new product reference (#129)

### DIFF
--- a/lib/xcake/xcode/project.rb
+++ b/lib/xcake/xcode/project.rb
@@ -88,7 +88,7 @@ module Xcake
 
         native_target.build_configuration_list = new(Xcodeproj::Project::Object::XCConfigurationList)
 
-        product = products_group.new_product_ref_for_target(native_target.product_name, native_target.product_type)
+        product = products_group.new_product_ref_for_target(native_target.product_name, target.type)
         native_target.product_reference = product
 
         targets << native_target


### PR DESCRIPTION
ui_test_bundle target type still doesn't put the right extension, PRODUCT_UTI_EXTENSIONS does not include ui_test_bundle key with value xctest.