### PR TITLE
Fix missing deep_merge issue (#162)

### DIFF
--- a/lib/xcake/constants.rb
+++ b/lib/xcake/constants.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/hash/deep_merge'
+
 module Xcake
   module Constants
     COMMON_BUILD_SETTINGS = Xcodeproj::Constants::COMMON_BUILD_SETTINGS.deep_merge(


### PR DESCRIPTION
I was unable to use the latest version of Xcake due to the error described in issue #162 and decided to see if I could fix it. I'm not sure why it's occurring for some people and not others--I assume the developers have been running the latest versions of Xcake and generating projects without any problems.

Adding this require statement fixes the issue for me. When I `gem build` it and install locally, I'm able to generate a working .xcodeproj for my iOS project that uses Xcake.