### PR TITLE
Fixes two errors

### DIFF
--- a/lib/xcake/constants.rb
+++ b/lib/xcake/constants.rb
@@ -2,7 +2,7 @@ require 'active_support/core_ext/hash/deep_merge'
 
 module Xcake
   module Constants
-    COMMON_BUILD_SETTINGS = Xcodeproj::Constants::COMMON_BUILD_SETTINGS.deep_merge(
+    COMMON_BUILD_SETTINGS = Xcodeproj::Constants::COMMON_BUILD_SETTINGS.dup.deep_merge(
       [:ios, :unit_test_bundle] => {
         'LD_RUNPATH_SEARCH_PATHS' => [
           '$(inherited)',

--- a/lib/xcake/generator/target_file_reference_generator.rb
+++ b/lib/xcake/generator/target_file_reference_generator.rb
@@ -30,6 +30,8 @@ module Xcake
     private
 
     def include_file_for_path_and_target(path, target)
+      return if File.directory?(path)
+
       file_reference = @context.file_reference_for_path(path)
       native_target = @context.native_object_for(target)
 

--- a/lib/xcake/version.rb
+++ b/lib/xcake/version.rb
@@ -1,3 +1,3 @@
 module Xcake
-  VERSION = '0.8.9'.freeze
+  VERSION = '0.8.10'.freeze
 end

--- a/xcake.gemspec
+++ b/xcake.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'cork'
   spec.add_dependency 'hooks', '~> 0.4.1'
   spec.add_dependency 'xcodeproj', '< 2.0.0', '>= 1.4.0'
+  spec.add_dependency 'deep_merge'
 
   # Lock `activesupport` (transitive dependency via `xcodeproj`) to keep supporting system ruby
   spec.add_dependency 'activesupport', '< 5'


### PR DESCRIPTION
## 'undefined method deep_merge' error

I discussed this in #164, and while having rails handy does fix it, this feels like a heavy handed solution (plus, I don't usually have rails installed, as was the case, again, today).

This fix has an explicit dependency on the `deep_merge` gem, much smaller than needing to use rails or active support.

## undefined method 'dirname'

This error occurred because I am using nested folders (`Source/Extensions/*.swift`).  Adding the guard `return if File.directory?(path)` seemed like a "too easy to work" fix, but actually the xcodeproje generated, all the groups were there, all the files, and I'm good to go (except for an issue with multiple targets, issue incoming for that).

I bumped the version numbers, I think this fix should go out so that people aren't waiting on #145 