### PR TITLE
Project fixes

### DIFF
--- a/lib/xcake/generator/target_file_reference_generator.rb
+++ b/lib/xcake/generator/target_file_reference_generator.rb
@@ -30,8 +30,6 @@ module Xcake
     private
 
     def include_file_for_path_and_target(path, target)
-      return if File.directory?(path)
-
       file_reference = @context.file_reference_for_path(path)
       native_target = @context.native_object_for(target)
 

--- a/lib/xcake/xcode/project.rb
+++ b/lib/xcake/xcode/project.rb
@@ -56,7 +56,6 @@ module Xcake
       def classes
         {}
       end
-      
 
       # Configures the Project for use with Xcake.
       # This makes sure we have sensible defaults and
@@ -166,7 +165,7 @@ module Xcake
         return nil unless base_name.to_s.include?('.lproj')
         parent_group = group_for_path(group_path)
 
-          group = parent_group[path.basename.to_s]
+        group = parent_group[path.basename.to_s]
 
         unless group
           group = new(PBXVariantGroup)

--- a/lib/xcake/xcode/project.rb
+++ b/lib/xcake/xcode/project.rb
@@ -49,6 +49,15 @@ module Xcake
         Xcodeproj::Constants::DEFAULT_OBJECT_VERSION.to_s
       end
 
+      def archive_version
+        Xcodeproj::Constants::LAST_KNOWN_ARCHIVE_VERSION.to_s
+      end
+
+      def classes
+        {}
+      end
+      
+
       # Configures the Project for use with Xcake.
       # This makes sure we have sensible defaults and
       # it as clean as possible.
@@ -157,7 +166,7 @@ module Xcake
         return nil unless base_name.to_s.include?('.lproj')
         parent_group = group_for_path(group_path)
 
-        group = parent_group[path.basename.to_s]
+          group = parent_group[path.basename.to_s]
 
         unless group
           group = new(PBXVariantGroup)


### PR DESCRIPTION
Two fixes:
* Asset catalogs actually ARE directories - remove check for directory (it's checked at an earlier step anyway)
* Added two default fields to generated project structure - apparently setting them prevents some tools from erroring out