### PR TITLE
Fix Issue #156

### DIFF
--- a/lib/xcake/generator/target_file_reference_generator.rb
+++ b/lib/xcake/generator/target_file_reference_generator.rb
@@ -13,13 +13,21 @@ module Xcake
       [TargetGenerator]
     end
 
+    ## This method will return an array of files based on the passed regular Exp
+    ## NOTE:- directories will not be included in the array
+    def get_cleaned_paths(reg_exp)
+      paths_without_directories = Dir.glob(reg_exp).select do |f|
+        !File.directory?(f)
+      end
+      paths = paths_without_directories.map do |f|
+        Pathname.new(f).cleanpath.to_s
+      end
+      paths
+    end
+
     def visit_target(target)
-      paths_to_include = Dir.glob(target.include_files).map do |f|
-        Pathname.new(f).cleanpath.to_s
-      end
-      paths_to_exclude = Dir.glob(target.exclude_files).map do |f|
-        Pathname.new(f).cleanpath.to_s
-      end
+      paths_to_include = get_cleaned_paths(target.include_files)
+      paths_to_exclude = get_cleaned_paths(target.exclude_files)
 
       paths = paths_to_include - paths_to_exclude
       paths.each do |p|

--- a/lib/xcake/generator/target_file_reference_generator.rb
+++ b/lib/xcake/generator/target_file_reference_generator.rb
@@ -16,8 +16,8 @@ module Xcake
     ## This method will return an array of files based on the passed regular Exp
     ## NOTE:- directories will not be included in the array
     def get_cleaned_paths(reg_exp)
-      paths_without_directories = Dir.glob(reg_exp).select do |f|
-        !File.directory?(f)
+      paths_without_directories = Dir.glob(reg_exp).reject do |f|
+        File.directory?(f)
       end
       paths = paths_without_directories.map do |f|
         Pathname.new(f).cleanpath.to_s

--- a/spec/generator/target_file_reference_generator_spec.rb
+++ b/spec/generator/target_file_reference_generator_spec.rb
@@ -67,7 +67,7 @@ module Xcake
       @generator.visit_target(@target)
     end
 
-    it "should ingore directories" do
+    it "should ignore directories" do
       dir_name = "my.test"
       file1 = "#{dir_name}/File1"
       file2 = "#{dir_name}/File2"

--- a/spec/generator/target_file_reference_generator_spec.rb
+++ b/spec/generator/target_file_reference_generator_spec.rb
@@ -67,6 +67,31 @@ module Xcake
       @generator.visit_target(@target)
     end
 
+    it 'should ingore directories' do
+      include_paths = [
+        'my.test',
+        'my.test/File1',
+        'my.test/File2'
+      ]
+      allowed_paths = [
+        'my.test/File1',
+        'my.test/File2'
+      ]
+      file_reference1 = double('File Reference 1')
+      file_reference2 = double('File Reference 2')
+      allow(@target).to receive(:include_files).and_return(include_paths)
+      allow(@target).to receive(:exclude_files).and_return([])
+      allow(Dir).to receive(:glob).with(include_paths).and_return(include_paths)
+      allow(Dir).to receive(:glob).with([]).and_return([])
+      allow(File).to receive(:directory?).and_return(false)
+      allow(File).to receive(:directory?).with('my.test').and_return(true)
+      allow(@context).to receive(:file_reference_for_path).with('my.test/File1').and_return(file_reference1)
+      allow(@context).to receive(:file_reference_for_path).with('my.test/File2').and_return(file_reference2)
+      
+      expect(@context).to_not receive(:file_reference_for_path).with('my.test')
+      @generator.visit_target(@target)
+    end
+
     it 'should ignore paths which shouldn\'t be installed' do
       exclude_paths = [
         './File'

--- a/spec/generator/target_file_reference_generator_spec.rb
+++ b/spec/generator/target_file_reference_generator_spec.rb
@@ -68,16 +68,14 @@ module Xcake
     end
 
     it "should ingore directories" do
-      dirName = "my.test"
-      file1 = "#{ dirName }/File1"
-      file2 = "#{ dirName }/File2"
+      dir_name = "my.test"
+      file1 = "#{dir_name}/File1"
+      file2 = "#{dir_name}/File2"
       include_paths = [
-        dirName,
+        dir_name,
         file1,
         file2
       ]
-      file_ref1 = double("File Reference 1")
-      file_ref2 = double("File Reference 2")
       allow(@target).to receive(:include_files).and_return(include_paths)
       allow(@target).to receive(:exclude_files).and_return([])
       allow(Dir).to receive(:glob).with(include_paths).and_return(include_paths)
@@ -86,7 +84,7 @@ module Xcake
       allow(File).to receive(:directory?).with("my.test").and_return(true)
       allow(@context).to receive(:file_reference_for_path).with(file1)
       allow(@context).to receive(:file_reference_for_path).with(file2)
-      expect(@context).to_not receive(:file_reference_for_path).with(dirName)
+      expect(@context).to_not receive(:file_reference_for_path).with(dir_name)
       @generator.visit_target(@target)
     end
 

--- a/spec/generator/target_file_reference_generator_spec.rb
+++ b/spec/generator/target_file_reference_generator_spec.rb
@@ -67,28 +67,26 @@ module Xcake
       @generator.visit_target(@target)
     end
 
-    it 'should ingore directories' do
+    it "should ingore directories" do
+      dirName = "my.test"
+      file1 = "#{ dirName }/File1"
+      file2 = "#{ dirName }/File2"
       include_paths = [
-        'my.test',
-        'my.test/File1',
-        'my.test/File2'
+        dirName,
+        file1,
+        file2
       ]
-      allowed_paths = [
-        'my.test/File1',
-        'my.test/File2'
-      ]
-      file_reference1 = double('File Reference 1')
-      file_reference2 = double('File Reference 2')
+      file_ref1 = double("File Reference 1")
+      file_ref2 = double("File Reference 2")
       allow(@target).to receive(:include_files).and_return(include_paths)
       allow(@target).to receive(:exclude_files).and_return([])
       allow(Dir).to receive(:glob).with(include_paths).and_return(include_paths)
       allow(Dir).to receive(:glob).with([]).and_return([])
       allow(File).to receive(:directory?).and_return(false)
-      allow(File).to receive(:directory?).with('my.test').and_return(true)
-      allow(@context).to receive(:file_reference_for_path).with('my.test/File1').and_return(file_reference1)
-      allow(@context).to receive(:file_reference_for_path).with('my.test/File2').and_return(file_reference2)
-      
-      expect(@context).to_not receive(:file_reference_for_path).with('my.test')
+      allow(File).to receive(:directory?).with("my.test").and_return(true)
+      allow(@context).to receive(:file_reference_for_path).with(file1)
+      allow(@context).to receive(:file_reference_for_path).with(file2)
+      expect(@context).to_not receive(:file_reference_for_path).with(dirName)
       @generator.visit_target(@target)
     end
 


### PR DESCRIPTION
Having . or - in folder names would crash xcake

This PR fixes it by checking if the file which needs to be added to a target is a directory or a file.
If it's a directory we skip over it.

This fixes #156 