### PR TITLE
Fix Issue #115

### DIFF
--- a/lib/xcake/dsl/project/sugar.rb
+++ b/lib/xcake/dsl/project/sugar.rb
@@ -97,13 +97,16 @@ module Xcake
 
       if host_target.type == :application
         test_target.all_configurations.each do |c|
-
-          c.settings['BUNDLE_LOADER'] = '$(TEST_HOST)'
-
-          if host_target.platform == :osx
-            c.settings["TEST_HOST"] = "$(BUILT_PRODUCTS_DIR)/#{host_target.name}.app/Contents/MacOS/#{host_target.name}"
+          if test_target.type == :ui_test_bundle
+            # Do nothing as they break UITests
+            # For more details https://github.com/jcampbell05/xcake/issues/115
           else
-            c.settings['TEST_HOST'] = "$(BUILT_PRODUCTS_DIR)/#{host_target.name}.app/#{host_target.name}"
+            c.settings["BUNDLE_LOADER"] = "$(TEST_HOST)"
+            if host_target.platform == :osx
+              c.settings["TEST_HOST"] = "$(BUILT_PRODUCTS_DIR)/#{host_target.name}.app/Contents/MacOS/#{host_target.name}"
+            else
+              c.settings["TEST_HOST"] = "$(BUILT_PRODUCTS_DIR)/#{host_target.name}.app/#{host_target.name}"
+            end
           end
         end
       end

--- a/spec/project/sugar_spec.rb
+++ b/spec/project/sugar_spec.rb
@@ -81,17 +81,16 @@ module Xcake
         expect(@target.language).to eq(:swift)
       end
 
-      it 'should set test host to application target executable' do
-        executable_path = "$(BUILT_PRODUCTS_DIR)/#{@app_target.name}.app/#{@app_target.name}"
+      it "should not set TEST_HOST setting" do
         test_host_set = satisfy do |c|
-          c.settings['TEST_HOST'] == executable_path
+          c.settings.key?("TEST_HOST") == false
         end
         expect(@target.all_configurations).to all(test_host_set)
       end
 
-      it 'should set bundle loader setting to test host' do
+      it "should not set BUNDLE_LOADER setting" do
         bundle_loader_set = satisfy do |c|
-          c.settings['BUNDLE_LOADER'] == '$(TEST_HOST)'
+          c.settings.key?("BUNDLE_LOADER") == false
         end
         expect(@target.all_configurations).to all(bundle_loader_set)
       end


### PR DESCRIPTION
Fixes Issue #115 

UITests would not run after generating a project from Cakefile, because of TEST_HOST and BUNDLE_LOADER in Target settings

This PR removes these two keys, so that UITests can be built